### PR TITLE
Add support for '--auto arch'

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ easily download them using a mix task:
 # with menu to select arch / version
 mix minio_server.download
 
+# download the latest SERVER binary matching the current machine
+mix minio_server.download --arch auto --version latest
+
 # download the latest SERVER binary for darwin-amd64
 mix minio_server.download --arch darwin-amd64 --version latest
 

--- a/lib/minio/config.ex
+++ b/lib/minio/config.ex
@@ -80,7 +80,9 @@ defmodule MinioServer.Config do
     executable_path(minio_arch())
   end
 
-  defp minio_arch do
+  @doc "MinIO architecture matching the current machine."
+  @spec minio_arch :: MinioServer.architecture()
+  def minio_arch do
     case {CpuInfo.os_type(), CpuInfo.cpu_type()} do
       {:macos, "arm64"} -> "darwin-arm64"
       {:macos, _} -> "darwin-amd64"

--- a/lib/mix/task/minio/download.ex
+++ b/lib/mix/task/minio/download.ex
@@ -171,6 +171,11 @@ defmodule Mix.Tasks.MinioServer.Download do
 
           Map.get(indexed_arches, index)
 
+        "auto" ->
+          arch = MinioServer.Config.minio_arch()
+          Mix.shell().info("Automatically detected architecture #{arch}")
+          arch
+
         arch ->
           String.trim(arch)
       end


### PR DESCRIPTION
This adds support for a new `auto` architecture which can be used to specify that the `minio_server.download` task should try to figure out the right architecture for the current machine on its own. Luckily, the functionality already existed (albeit in a simple version) in the `MinioServer.Config.minio_arch/0` function.

Together with `--version latest`, this permits fetching a current MinIO binary for the current machine in an entirely unattended fashion, e.g.

```sh
frerich@Frerichs-Mini minio_server % mix minio_server.download --arch auto --version latest
Automatically detected architecture darwin-arm64

22:48:54.493 [info] SERVER: 2021-09-09T21-37-07Z

22:48:54.495 [info] Download of minio client binary for darwin-arm64 (version 2021-09-09T21-37-07Z).

22:50:02.380 [info] Checksum matched. MinioServer binary was successfully downloaded.
frerich@Frerichs-Mini minio_server %
```