### PR TITLE
Add tls support without x509 lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ s3_config = [
   minio_path: "data" # Defaults to ./minio in your mix project
 ]
 
+# HTTPS (with TLS) — required for SSE-C encryption
+# Self-signed certs are auto-generated if public.crt and private.key
+# don't exist in the certs_dir yet.
+s3_config = [
+  access_key_id: "minio_key",
+  secret_access_key: "minio_secret",
+  scheme: "https://",
+  region: "local",
+  host: "127.0.0.1",
+  port: 9000,
+  minio_path: "data",
+  certs_dir: "/path/to/certs"
+]
+
 # In a supervisor
 children = [
   {MinioServer, s3_config}

--- a/lib/minio.ex
+++ b/lib/minio.ex
@@ -41,7 +41,49 @@ defmodule MinioServer do
   """
   use Supervisor
   require Logger
+  require Record
   alias MinioServer.Config
+
+  # OTP ASN.1 records for self-signed certificate generation
+  @otp_pub_key "public_key/include/OTP-PUB-KEY.hrl"
+
+  Record.defrecordp(
+    :otp_tbs_certificate,
+    :OTPTBSCertificate,
+    Record.extract(:OTPTBSCertificate, from_lib: @otp_pub_key)
+  )
+
+  Record.defrecordp(
+    :signature_algorithm,
+    :SignatureAlgorithm,
+    Record.extract(:SignatureAlgorithm, from_lib: @otp_pub_key)
+  )
+
+  Record.defrecordp(:validity, :Validity, Record.extract(:Validity, from_lib: @otp_pub_key))
+
+  Record.defrecordp(
+    :spki,
+    :OTPSubjectPublicKeyInfo,
+    Record.extract(:OTPSubjectPublicKeyInfo, from_lib: @otp_pub_key)
+  )
+
+  Record.defrecordp(
+    :pk_algorithm,
+    :PublicKeyAlgorithm,
+    Record.extract(:PublicKeyAlgorithm, from_lib: @otp_pub_key)
+  )
+
+  Record.defrecordp(
+    :cert_extension,
+    :Extension,
+    Record.extract(:Extension, from_lib: @otp_pub_key)
+  )
+
+  Record.defrecordp(
+    :attr_type_and_value,
+    :AttributeTypeAndValue,
+    Record.extract(:AttributeTypeAndValue, from_lib: @otp_pub_key)
+  )
 
   @type architecture :: String.t()
   @type version :: String.t()
@@ -137,35 +179,87 @@ defmodule MinioServer do
     unless File.exists?(cert_file) and File.exists?(key_file) do
       File.mkdir_p!(certs_dir)
 
-      key = X509.PrivateKey.new_rsa(2048)
+      key = :public_key.generate_key({:rsa, 2048, 65537})
+      {:RSAPrivateKey, _, modulus, pub_exp, _, _, _, _, _, _, _} = key
 
-      san_entries =
-        case :inet.parse_address(String.to_charlist(host)) do
-          {:ok, {a, b, c, d}} ->
-            [{:iPAddress, <<a, b, c, d>>}, "localhost"]
+      rdn =
+        {:rdnSequence, [[attr_type_and_value(type: {2, 5, 4, 3}, value: {:utf8String, host})]]}
 
-          {:ok, {a, b, c, d, e, f, g, h}} ->
-            [
-              {:iPAddress, <<a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>>},
-              "localhost"
-            ]
+      now = DateTime.utc_now()
+      not_after = DateTime.add(now, 3650 * 86400, :second)
 
-          {:error, _} ->
-            [host, "localhost"]
-        end
-
-      cert =
-        X509.Certificate.self_signed(key, "/CN=#{host}",
-          validity: 3650,
+      tbs =
+        otp_tbs_certificate(
+          version: :v3,
+          serialNumber: :crypto.strong_rand_bytes(16) |> :binary.decode_unsigned(),
+          signature:
+            signature_algorithm(
+              algorithm: {1, 2, 840, 113_549, 1, 1, 11},
+              parameters: :NULL
+            ),
+          issuer: rdn,
+          validity:
+            validity(
+              notBefore: {:utcTime, format_utc_time(now)},
+              notAfter: {:utcTime, format_utc_time(not_after)}
+            ),
+          subject: rdn,
+          subjectPublicKeyInfo:
+            spki(
+              algorithm:
+                pk_algorithm(
+                  algorithm: {1, 2, 840, 113_549, 1, 1, 1},
+                  parameters: :NULL
+                ),
+              subjectPublicKey: {:RSAPublicKey, modulus, pub_exp}
+            ),
           extensions: [
-            subject_alt_name: X509.Certificate.Extension.subject_alt_name(san_entries)
+            cert_extension(
+              extnID: {2, 5, 29, 17},
+              critical: false,
+              extnValue: build_san_entries(host)
+            )
           ]
         )
 
-      File.write!(key_file, X509.PrivateKey.to_pem(key))
-      File.write!(cert_file, X509.Certificate.to_pem(cert))
+      cert_der = :public_key.pkix_sign(tbs, key)
+
+      key_pem = :public_key.pem_encode([:public_key.pem_entry_encode(:RSAPrivateKey, key)])
+      cert_pem = :public_key.pem_encode([{:Certificate, cert_der, :not_encrypted}])
+
+      File.write!(key_file, key_pem)
+      File.write!(cert_file, cert_pem)
 
       Logger.info("Generated self-signed TLS certs for MinIO at #{certs_dir}")
     end
+  end
+
+  defp build_san_entries(host) do
+    ip_or_dns =
+      case :inet.parse_address(String.to_charlist(host)) do
+        {:ok, {a, b, c, d}} ->
+          [{:iPAddress, <<a, b, c, d>>}]
+
+        {:ok, {a, b, c, d, e, f, g, h}} ->
+          [{:iPAddress, <<a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>>}]
+
+        {:error, _} ->
+          [{:dNSName, String.to_charlist(host)}]
+      end
+
+    ip_or_dns ++ [{:dNSName, ~c"localhost"}]
+  end
+
+  defp format_utc_time(datetime) do
+    :lists.flatten(
+      :io_lib.format(~c"~2..0B~2..0B~2..0B~2..0B~2..0B~2..0BZ", [
+        rem(datetime.year, 100),
+        datetime.month,
+        datetime.day,
+        datetime.hour,
+        datetime.minute,
+        datetime.second
+      ])
+    )
   end
 end

--- a/lib/minio.ex
+++ b/lib/minio.ex
@@ -17,8 +17,8 @@ defmodule MinioServer do
       ]
 
       # HTTPS (with TLS) — required for SSE-C encryption
-      # Self-signed certs are auto-generated if public.crt and private.key
-      # don't exist in the certs_dir yet.
+      # Self-signed certs are auto-generated if both public.crt and 
+      # private.key don't exist in the certs_dir yet.
       s3_config = [
         access_key_id: "minio_key",
         secret_access_key: "minio_secret",

--- a/lib/minio.ex
+++ b/lib/minio.ex
@@ -16,6 +16,20 @@ defmodule MinioServer do
         minio_path: "data" # Defaults to minio in your mix project
       ]
 
+      # HTTPS (with TLS) — required for SSE-C encryption
+      # Self-signed certs are auto-generated if public.crt and private.key
+      # don't exist in the certs_dir yet.
+      s3_config = [
+        access_key_id: "minio_key",
+        secret_access_key: "minio_secret",
+        scheme: "https://",
+        region: "local",
+        host: "127.0.0.1",
+        port: 9000,
+        minio_path: "data",
+        certs_dir: "/path/to/certs"
+      ]
+
       # In a supervisor
       children = [
         {MinioServer, s3_config}
@@ -33,6 +47,12 @@ defmodule MinioServer do
   @type version :: String.t()
 
   def start_link(init_arg) do
+    host = Keyword.get(init_arg, :host, "127.0.0.1")
+
+    if certs_dir = Keyword.get(init_arg, :certs_dir) do
+      ensure_certs(certs_dir, host)
+    end
+
     Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
   end
 
@@ -49,6 +69,7 @@ defmodule MinioServer do
     additional_args =
       Enum.reduce(init_arg, [], fn
         {:console_address, addr}, acc -> [["--console-address", addr] | acc]
+        {:certs_dir, dir}, acc -> [["--certs-dir", dir] | acc]
         _, acc -> acc
       end)
       |> Enum.reverse()
@@ -82,7 +103,8 @@ defmodule MinioServer do
 
     if ui do
       ui_port = if port = Keyword.get(init_arg, :console_address), do: port, else: ":#{port}"
-      Logger.info("Access minio server UI at http://#{host}#{ui_port}")
+      scheme = if Keyword.has_key?(init_arg, :certs_dir), do: "https", else: "http"
+      Logger.info("Access minio server UI at #{scheme}://#{host}#{ui_port}")
     end
 
     Supervisor.init(children, strategy: :one_for_one)
@@ -106,4 +128,44 @@ defmodule MinioServer do
 
   @spec download_client(MinioServer.architecture(), keyword()) :: :exists | :ok | :timeout
   defdelegate download_client(arch, opts \\ []), to: MinioServer.DownloaderClient, as: :download
+
+  @doc false
+  def ensure_certs(certs_dir, host) do
+    cert_file = Path.join(certs_dir, "public.crt")
+    key_file = Path.join(certs_dir, "private.key")
+
+    unless File.exists?(cert_file) and File.exists?(key_file) do
+      File.mkdir_p!(certs_dir)
+
+      key = X509.PrivateKey.new_rsa(2048)
+
+      san_entries =
+        case :inet.parse_address(String.to_charlist(host)) do
+          {:ok, {a, b, c, d}} ->
+            [{:iPAddress, <<a, b, c, d>>}, "localhost"]
+
+          {:ok, {a, b, c, d, e, f, g, h}} ->
+            [
+              {:iPAddress, <<a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>>},
+              "localhost"
+            ]
+
+          {:error, _} ->
+            [host, "localhost"]
+        end
+
+      cert =
+        X509.Certificate.self_signed(key, "/CN=#{host}",
+          validity: 3650,
+          extensions: [
+            subject_alt_name: X509.Certificate.Extension.subject_alt_name(san_entries)
+          ]
+        )
+
+      File.write!(key_file, X509.PrivateKey.to_pem(key))
+      File.write!(cert_file, X509.Certificate.to_pem(cert))
+
+      Logger.info("Generated self-signed TLS certs for MinIO at #{certs_dir}")
+    end
+  end
 end

--- a/lib/minio/admin.ex
+++ b/lib/minio/admin.ex
@@ -64,8 +64,9 @@ defmodule MinioServer.Admin do
     secret = Keyword.fetch!(config, :secret_access_key)
     host = Keyword.get(config, :host, "127.0.0.1")
     port = Keyword.get(config, :port, 9000)
+    scheme = if Keyword.has_key?(config, :certs_dir), do: "https", else: "http"
 
-    {"MC_HOST_#{@alias}", "http://#{key}:#{secret}@#{host}:#{port}"}
+    {"MC_HOST_#{@alias}", "#{scheme}://#{key}:#{secret}@#{host}:#{port}"}
   end
 
   defp mc do

--- a/mix.exs
+++ b/mix.exs
@@ -33,6 +33,7 @@ defmodule MinioServer.MixProject do
   defp deps do
     [
       {:muontrap, "~> 0.5.0"},
+      {:x509, "~> 0.9"},
       {:jason, "~> 1.1"},
       {:ex_aws, "~> 2.0", optional: true},
       {:ex_aws_s3, "~> 2.2", only: [:dev, :test]},

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule MinioServer.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger, :inets]
+      extra_applications: [:logger, :inets, :public_key, :crypto]
     ]
   end
 
@@ -33,7 +33,6 @@ defmodule MinioServer.MixProject do
   defp deps do
     [
       {:muontrap, "~> 0.5.0"},
-      {:x509, "~> 0.9"},
       {:jason, "~> 1.1"},
       {:ex_aws, "~> 2.0", optional: true},
       {:ex_aws_s3, "~> 2.2", only: [:dev, :test]},

--- a/mix.lock
+++ b/mix.lock
@@ -21,4 +21,5 @@
   "sweet_xml": {:hex, :sweet_xml, "0.7.1", "a2cac8e2101237e617dfa9d427d44b8aff38ba6294f313ffb4667524d6b71b98", [:mix], [], "hexpm", "8bc7b7b584a6a87113071d0d2fd39fe2251cf2224ecaeed7093bdac1b9c1555f"},
   "telemetry": {:hex, :telemetry, "0.4.3", "a06428a514bdbc63293cd9a6263aad00ddeb66f608163bdec7c8995784080818", [:rebar3], [], "hexpm", "eb72b8365ffda5bed68a620d1da88525e326cb82a75ee61354fc24b844768041"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
+  "x509": {:hex, :x509, "0.9.2", "a75aa605348abd905990f3d2dc1b155fcde4e030fa2f90c4a91534405dce0f6e", [:mix], [], "hexpm", "4c5ede75697e565d4b0f5be04c3b71bb1fd3a090ea243af4bd7dae144e48cfc7"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -21,5 +21,4 @@
   "sweet_xml": {:hex, :sweet_xml, "0.7.1", "a2cac8e2101237e617dfa9d427d44b8aff38ba6294f313ffb4667524d6b71b98", [:mix], [], "hexpm", "8bc7b7b584a6a87113071d0d2fd39fe2251cf2224ecaeed7093bdac1b9c1555f"},
   "telemetry": {:hex, :telemetry, "0.4.3", "a06428a514bdbc63293cd9a6263aad00ddeb66f608163bdec7c8995784080818", [:rebar3], [], "hexpm", "eb72b8365ffda5bed68a620d1da88525e326cb82a75ee61354fc24b844768041"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
-  "x509": {:hex, :x509, "0.9.2", "a75aa605348abd905990f3d2dc1b155fcde4e030fa2f90c4a91534405dce0f6e", [:mix], [], "hexpm", "4c5ede75697e565d4b0f5be04c3b71bb1fd3a090ea243af4bd7dae144e48cfc7"},
 }

--- a/test/minio_test.exs
+++ b/test/minio_test.exs
@@ -1,4 +1,150 @@
 defmodule MinioServerTest do
   use ExUnit.Case
   doctest MinioServer
+
+  defp base_config(extra \\ []) do
+    [
+      access_key_id: "test_key",
+      secret_access_key: "test_secret",
+      minio_executable: "/bin/false"
+    ] ++ extra
+  end
+
+  defp get_child_spec(config) do
+    {:ok, {_sup_flags, [child_spec]}} = MinioServer.init(config)
+    {MuonTrap.Daemon, :start_link, [executable, cli_args, daemon_opts]} = child_spec.start
+    %{executable: executable, cli_args: cli_args, daemon_opts: daemon_opts}
+  end
+
+  describe "TLS / certs_dir" do
+    test "certs_dir is passed as --certs-dir" do
+      %{cli_args: cli_args} = get_child_spec(base_config(certs_dir: "/path/to/certs"))
+
+      assert "--certs-dir" in cli_args
+      assert "/path/to/certs" in cli_args
+
+      # Verify they appear consecutively
+      idx = Enum.find_index(cli_args, &(&1 == "--certs-dir"))
+      assert Enum.at(cli_args, idx + 1) == "/path/to/certs"
+    end
+
+    test "without certs_dir, no --certs-dir flag" do
+      %{cli_args: cli_args} = get_child_spec(base_config())
+
+      refute "--certs-dir" in cli_args
+    end
+
+    test "certs_dir works alongside console_address" do
+      config = base_config(certs_dir: "/path/to/certs", console_address: ":9001")
+      %{cli_args: cli_args} = get_child_spec(config)
+
+      assert "--certs-dir" in cli_args
+      assert "/path/to/certs" in cli_args
+      assert "--console-address" in cli_args
+      assert ":9001" in cli_args
+    end
+  end
+
+  describe "ensure_certs" do
+    @tag :tmp_dir
+    test "generates valid PEM cert and key files", %{tmp_dir: tmp_dir} do
+      certs_dir = Path.join(tmp_dir, "certs")
+
+      MinioServer.ensure_certs(certs_dir, "127.0.0.1")
+
+      cert_file = Path.join(certs_dir, "public.crt")
+      key_file = Path.join(certs_dir, "private.key")
+
+      assert File.exists?(cert_file)
+      assert File.exists?(key_file)
+
+      # Verify they're valid PEM
+      cert_pem = File.read!(cert_file)
+      key_pem = File.read!(key_file)
+
+      assert [{:Certificate, cert_der, :not_encrypted}] = :public_key.pem_decode(cert_pem)
+      assert [{:RSAPrivateKey, _key_der, :not_encrypted}] = :public_key.pem_decode(key_pem)
+
+      # Verify the cert can be decoded
+      cert = :public_key.pkix_decode_cert(cert_der, :otp)
+      assert cert != nil
+    end
+
+    @tag :tmp_dir
+    test "does not regenerate if certs already exist", %{tmp_dir: tmp_dir} do
+      certs_dir = Path.join(tmp_dir, "certs")
+      File.mkdir_p!(certs_dir)
+
+      File.write!(Path.join(certs_dir, "public.crt"), "existing cert")
+      File.write!(Path.join(certs_dir, "private.key"), "existing key")
+
+      MinioServer.ensure_certs(certs_dir, "127.0.0.1")
+
+      assert File.read!(Path.join(certs_dir, "public.crt")) == "existing cert"
+      assert File.read!(Path.join(certs_dir, "private.key")) == "existing key"
+    end
+
+    @tag :tmp_dir
+    test "regenerates if only cert exists but key is missing", %{tmp_dir: tmp_dir} do
+      certs_dir = Path.join(tmp_dir, "certs")
+      File.mkdir_p!(certs_dir)
+
+      File.write!(Path.join(certs_dir, "public.crt"), "orphan cert")
+
+      MinioServer.ensure_certs(certs_dir, "127.0.0.1")
+
+      # Should have regenerated since private.key was missing
+      cert_pem = File.read!(Path.join(certs_dir, "public.crt"))
+      assert cert_pem != "orphan cert"
+      assert [{:Certificate, _, :not_encrypted}] = :public_key.pem_decode(cert_pem)
+    end
+
+    @tag :tmp_dir
+    test "generates cert with IPv6 SAN entry", %{tmp_dir: tmp_dir} do
+      certs_dir = Path.join(tmp_dir, "certs")
+
+      MinioServer.ensure_certs(certs_dir, "::1")
+
+      cert_pem = File.read!(Path.join(certs_dir, "public.crt"))
+      assert [{:Certificate, cert_der, :not_encrypted}] = :public_key.pem_decode(cert_pem)
+      cert = :public_key.pkix_decode_cert(cert_der, :otp)
+      assert cert != nil
+    end
+
+    @tag :tmp_dir
+    test "generates cert with hostname SAN entry", %{tmp_dir: tmp_dir} do
+      certs_dir = Path.join(tmp_dir, "certs")
+
+      MinioServer.ensure_certs(certs_dir, "minio.local")
+
+      cert_pem = File.read!(Path.join(certs_dir, "public.crt"))
+      assert [{:Certificate, cert_der, :not_encrypted}] = :public_key.pem_decode(cert_pem)
+      cert = :public_key.pkix_decode_cert(cert_der, :otp)
+      assert cert != nil
+    end
+  end
+
+  describe "Admin.host_env (via alias_export)" do
+    test "uses http scheme without certs_dir" do
+      config = base_config()
+      export = MinioServer.Admin.alias_export(config)
+
+      assert export =~ "http://test_key:test_secret@127.0.0.1:9000"
+      refute export =~ "https://"
+    end
+
+    test "uses https scheme when certs_dir is set" do
+      config = base_config(certs_dir: "/path/to/certs")
+      export = MinioServer.Admin.alias_export(config)
+
+      assert export =~ "https://test_key:test_secret@127.0.0.1:9000"
+    end
+
+    test "uses custom host and port" do
+      config = base_config(host: "192.168.1.10", port: 9999)
+      export = MinioServer.Admin.alias_export(config)
+
+      assert export =~ "192.168.1.10:9999"
+    end
+  end
 end


### PR DESCRIPTION
This is what it would look like?

I think the library is cleaner, but I would not oppose this.